### PR TITLE
Switch to default golang image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
-FROM golang:1.18-alpine as build
+FROM golang:1.18 as build
 
 WORKDIR /src
 COPY . .
 RUN go build
 
-FROM golang:1.18-alpine AS final
+FROM golang:1.18 AS final
 ENV TAGS_ADDRESS="0.0.0.0:5000"
 EXPOSE 5000
 WORKDIR /app
 ARG user=rinkudesu
-RUN apk add --no-cache curl 
-RUN adduser -D -H -s /bin/false $user
-RUN addgroup $user $user
+RUN useradd -M -s /bin/false $user
 COPY --from=build --chown=$user:$user /src/rinkudesu-tags .
 RUN chmod 100 rinkudesu-tags
 USER $user


### PR DESCRIPTION
Due to issues encountered on another branch, the default golang image is switched from alpine back to default.
