### PR TITLE
Tag list pagination

### DIFF
--- a/controllers/tags_controller.go
+++ b/controllers/tags_controller.go
@@ -18,7 +18,9 @@ func NewTagsController(repository *repositories.TagsRepository) *TagsController 
 
 func (controller *TagsController) GetTags(c *gin.Context) {
 	var query struct {
-		Name string `form:"name"`
+		Name   string `form:"name"`
+		Offset int    `form:"offset"`
+		Limit  int    `form:"limit"`
 	}
 	if err := c.BindQuery(&query); err != nil {
 		log.Warnf("Failed to bind tags query string: %s", err.Error())
@@ -26,7 +28,7 @@ func (controller *TagsController) GetTags(c *gin.Context) {
 		return
 	}
 
-	tags, err := controller.repository.GetTags(GetUserInfo(c), query.Name)
+	tags, err := controller.repository.GetTags(GetUserInfo(c), query.Name, query.Offset, query.Limit)
 	if err != nil {
 		c.Status(http.StatusInternalServerError)
 		return

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jackc/pgconn v1.13.0
 	github.com/jackc/pgtype v1.13.0
 	github.com/jackc/pgx/v4 v4.17.2
-	github.com/rinkudesu/curry v0.1.1
+	github.com/rinkudesu/curry v0.2.0
 	github.com/rinkudesu/go-kafka v0.1.2
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/rinkudesu/curry v0.1.1 h1:3Vi1wX3iTt6uPEigfKt6lXf3empI2oRsnAGKNrh9kE8=
-github.com/rinkudesu/curry v0.1.1/go.mod h1:SL4WcYyjtntmu4bSCOwt61nxOdgQbJ/pa47MbQP6KH0=
+github.com/rinkudesu/curry v0.2.0 h1:PLEN5gvBybuIhrr+xeTt825IajJLe/C6uxZc8OJ4Lz8=
+github.com/rinkudesu/curry v0.2.0/go.mod h1:SL4WcYyjtntmu4bSCOwt61nxOdgQbJ/pa47MbQP6KH0=
 github.com/rinkudesu/go-kafka v0.1.2 h1:7IGOmJCUa3AevTbqfOPk8H0xcB6Unh8/L/hnrUNEoCQ=
 github.com/rinkudesu/go-kafka v0.1.2/go.mod h1:XLXRPWHcwBPiWD8oW0ENSIuWjr3fFSdQMQVnLKFNroE=
 github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a/go.mod h1:4r5QyqhjIWCcK8DO4KMclc5Iknq5qVBAlbYYzAbUScQ=

--- a/repositories/tags_repository.go
+++ b/repositories/tags_repository.go
@@ -19,11 +19,11 @@ func NewTagsRepository(state *services.GlobalState) *TagsRepository {
 	return &TagsRepository{connection: state.DbConnection}
 }
 
-func (repository *TagsRepository) GetTags(userInfo *models.UserInfo, name string) ([]*models.Tag, error) {
+func (repository *TagsRepository) GetTags(userInfo *models.UserInfo, name string, offset int, limit int) ([]*models.Tag, error) {
 	userIdFilter := curry.NewWhereItem("user_id", "=", curry.NewParameter(userInfo.UserId))
 	nameLike := fmt.Sprintf("%%%s%%", strings.ToUpper(name))
 	tagNameFilter := curry.NewWhereItem("name_normalised", "like", curry.NewOptionalParameter(nameLike, "'%%'"))
-	query := curry.Select("id, name", "tags", "").Where(curry.WhereBegin(userIdFilter).And(tagNameFilter))
+	query := curry.Select("id, name", "tags", "").OrderBy("name_normalised").Where(curry.WhereBegin(userIdFilter).And(tagNameFilter)).Limit(limit).Offset(offset)
 	sql, parameters, err := query.ToExecutable()
 	if err != nil {
 		log.Warnf("Failed to generate sql query: %s", err.Error())

--- a/repositories/tags_repository_test.go
+++ b/repositories/tags_repository_test.go
@@ -44,7 +44,7 @@ func TestTagsRepository_GetAll_TagsPresent(t *testing.T) {
 	}
 	tagIds := test.addTags(t, tags)
 
-	result, err := test.repo.GetTags(test.userInfo, "")
+	result, err := test.repo.GetTags(test.userInfo, "", 0, 0)
 
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(result))
@@ -67,7 +67,7 @@ func TestTagsRepository_GetAll_TagsCreatedByAnotherUser_ReturnsEmptySlice(t *tes
 	anotherUserId, _ := uuid.NewV4()
 	anotherUserInfo := models.UserInfo{UserId: anotherUserId}
 
-	result, err := test.repo.GetTags(&anotherUserInfo, "")
+	result, err := test.repo.GetTags(&anotherUserInfo, "", 0, 0)
 
 	assert.Nil(t, err)
 	assert.Empty(t, result)
@@ -78,7 +78,7 @@ func TestTagsRepository_GetAll_NoTagsReturnsEmpty(t *testing.T) {
 	t.Parallel()
 	t.Cleanup(test.close)
 
-	result, err := test.repo.GetTags(test.userInfo, "")
+	result, err := test.repo.GetTags(test.userInfo, "", 0, 0)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, result)
@@ -154,7 +154,7 @@ func TestTagsRepository_Create_DuplicateName(t *testing.T) {
 	assert.Nil(t, result)
 	assert.NotNil(t, err)
 	assert.Equal(t, AlreadyExistsErr, err)
-	tags, _ := test.repo.GetTags(test.userInfo, "")
+	tags, _ := test.repo.GetTags(test.userInfo, "", 0, 0)
 	assert.Equal(t, 1, len(tags))
 }
 
@@ -220,7 +220,7 @@ func TestTagsRepository_Update_TagNotFound(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, NotFoundErr, err)
 	assert.Nil(t, result)
-	loadedTags, _ := test.repo.GetTags(test.userInfo, "")
+	loadedTags, _ := test.repo.GetTags(test.userInfo, "", 0, 0)
 	assert.Empty(t, loadedTags)
 }
 
@@ -239,7 +239,7 @@ func TestTagsRepository_Update_TagCreatedByAnotherUser_NotFound(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, NotFoundErr, err)
 	assert.Nil(t, result)
-	loadedTags, _ := test.repo.GetTags(test.userInfo, "")
+	loadedTags, _ := test.repo.GetTags(test.userInfo, "", 0, 0)
 	assert.Equal(t, "test", loadedTags[0].Name)
 }
 
@@ -253,7 +253,7 @@ func TestTagsRepository_Delete_Deletes(t *testing.T) {
 	err := test.repo.Delete(tag.Id, test.userInfo)
 
 	assert.Nil(t, err)
-	tags, _ := test.repo.GetTags(test.userInfo, "")
+	tags, _ := test.repo.GetTags(test.userInfo, "", 0, 0)
 	assert.Empty(t, tags)
 }
 
@@ -267,7 +267,7 @@ func TestTagsRepository_Delete_NotFound(t *testing.T) {
 
 	assert.NotNil(t, err)
 	assert.Equal(t, NotFoundErr, err)
-	tags, _ := test.repo.GetTags(test.userInfo, "")
+	tags, _ := test.repo.GetTags(test.userInfo, "", 0, 0)
 	assert.Empty(t, tags)
 }
 
@@ -354,7 +354,7 @@ func TestTagsRepository_DeleteAllOfUser_NoneExistForUser(t *testing.T) {
 	err := test.repo.DeleteAllOfUser(test.userInfo.UserId)
 
 	assert.Nil(t, err)
-	existingLinks, _ := test.repo.GetTags(&anotherUserInfo, "")
+	existingLinks, _ := test.repo.GetTags(&anotherUserInfo, "", 0, 0)
 	assert.NotEmpty(t, existingLinks)
 }
 
@@ -369,7 +369,7 @@ func TestTagsRepository_DeleteAllOfUser_ExistForUser(t *testing.T) {
 	err := test.repo.DeleteAllOfUser(test.userInfo.UserId)
 
 	assert.Nil(t, err)
-	existingLinks, _ := test.repo.GetTags(test.userInfo, "")
+	existingLinks, _ := test.repo.GetTags(test.userInfo, "", 0, 0)
 	assert.Empty(t, existingLinks)
 }
 
@@ -389,7 +389,7 @@ func TestTagsRepository_GetAllWithNameFilter_ReturnsMatchingOnly(t *testing.T) {
 	}
 	tagIds := test.addTags(t, tags)
 
-	result, err := test.repo.GetTags(test.userInfo, "tag")
+	result, err := test.repo.GetTags(test.userInfo, "tag", 0, 0)
 
 	assert.Nil(t, err)
 	assert.Equal(t, 6, len(result))
@@ -400,4 +400,22 @@ func TestTagsRepository_GetAllWithNameFilter_ReturnsMatchingOnly(t *testing.T) {
 	for i := 7; i < 8; i++ {
 		assert.False(t, test.containsTag(tags[i], result))
 	}
+}
+
+func TestTagsRepository_GetAllWithOffsetLimit_ReturnsRequiredOnly(t *testing.T) {
+	test := newTagsRepositoryTests()
+	t.Parallel()
+	t.Cleanup(test.close)
+	tags := []*models.Tag{
+		{Name: "tag 1"},
+		{Name: "tag 2"},
+		{Name: "tag 3"},
+	}
+	_ = test.addTags(t, tags)
+
+	result, err := test.repo.GetTags(test.userInfo, "", 1, 1)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(result))
+	assert.Equal(t, tags[1].Name, result[0].Name)
 }


### PR DESCRIPTION
Allow for tag list pagination by providing `Limit` and `Offset` query parameters, in a simmilar fashion to how the links microservice does this.

This also contains a bump of curry, as it was impossible to order the list whilst applying limit and offset.

Closes #93 