### PR TITLE
Add tag colour identifier

### DIFF
--- a/data/migrations/migration_definition_provider.go
+++ b/data/migrations/migration_definition_provider.go
@@ -20,7 +20,7 @@ func getMigrationDefinitions(start int, end int) *[]string {
 		if err != nil {
 			log.Panicf("Failed to open migration file for migration %d: %s", i, err.Error())
 		}
-		definitions[start-i] = string(file)
+		definitions[start+i] = string(file)
 	}
 	return &definitions
 }

--- a/data/migrations/sql/1.sql
+++ b/data/migrations/sql/1.sql
@@ -1,0 +1,1 @@
+alter table tags add column colour varchar(7) not null default '#edbd1e';

--- a/models/tag.go
+++ b/models/tag.go
@@ -5,14 +5,18 @@ import "github.com/gofrs/uuid"
 type Tag struct {
 	Id   uuid.UUID `json:"id" binding:"required"`
 	Name string    `json:"name" binding:"required,max=50"`
+	// Colour represents a visual tag identifier. Should be provided in HTML format, as in "#aabbcc".
+	Colour string `json:"colour" binding:"required,max=7"`
 }
 
 type TagCreateViewModel struct {
-	Name string `json:"name" binding:"required,max=50"`
+	Name   string `json:"name" binding:"required,max=50"`
+	Colour string `json:"colour" binding:"required,max=7"`
 }
 
 func (vm *TagCreateViewModel) GetTag() Tag {
 	return Tag{
-		Name: vm.Name,
+		Name:   vm.Name,
+		Colour: vm.Colour,
 	}
 }


### PR DESCRIPTION
The back-end piece of #75. This allows (requires) tags to have a colour assigned to them. The colour is stored in hex format (as in `#aabbcc`) for every tag. It can be updated at any point.

The front-end part of this will come next.

There's also a fix for me being unable to count properly when deciding which migrations to apply (as this is the first time a new migration has been added).