### PR TITLE
Replace `Status` usages with `AbortWithStatus` where applicable

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -22,7 +22,7 @@ func BindJson(c *gin.Context, obj any) error {
 	err := c.BindJSON(obj)
 	if err != nil {
 		log.Infof("Failed to parse json: %s", err.Error())
-		c.Status(http.StatusBadRequest)
+		c.AbortWithStatus(http.StatusBadRequest)
 	}
 	return err
 }

--- a/controllers/link_tags_controller.go
+++ b/controllers/link_tags_controller.go
@@ -30,24 +30,24 @@ func (controller *LinkTagsController) Create(c *gin.Context) {
 
 	// ignore duplicate values errors, since they just mean required data is already available
 	if err = controller.linksRepository.Create(&models.Link{Id: linkTag.LinkId}, userInfo); err != repositories.AlreadyExistsErr {
-		c.Status(http.StatusInternalServerError)
+		c.AbortWithStatus(http.StatusInternalServerError)
 		return
 	}
 	// to create a link-tag the tag must already exist, since we utilise the id here
 	// if the tag no longer exists, then assume it was deleted and return error
 	if tagExists, _ := controller.tagsRepository.Exists(linkTag.TagId, userInfo); !tagExists {
-		c.Status(http.StatusNotFound)
+		c.AbortWithStatus(http.StatusNotFound)
 		return
 	}
 
 	err = controller.repository.Create(&linkTag, userInfo)
 	if err != nil {
 		if err == repositories.AlreadyExistsErr {
-			c.Status(http.StatusBadRequest)
+			c.AbortWithStatus(http.StatusBadRequest)
 		} else if err == repositories.NotFoundErr {
-			c.Status(http.StatusNotFound)
+			c.AbortWithStatus(http.StatusNotFound)
 		} else {
-			c.Status(http.StatusInternalServerError)
+			c.AbortWithStatus(http.StatusInternalServerError)
 		}
 		return
 	}
@@ -73,9 +73,9 @@ func (controller *LinkTagsController) Delete(c *gin.Context) {
 	err = controller.repository.Remove(parsedIds[0], parsedIds[1], GetUserInfo(c))
 	if err != nil {
 		if err == repositories.NotFoundErr {
-			c.Status(http.StatusNotFound)
+			c.AbortWithStatus(http.StatusNotFound)
 		} else {
-			c.Status(http.StatusInternalServerError)
+			c.AbortWithStatus(http.StatusInternalServerError)
 		}
 		return
 	}
@@ -92,9 +92,9 @@ func (controller *LinkTagsController) GetLinksForTag(c *gin.Context) {
 	result, err := controller.repository.GetLinksForTag(id, GetUserInfo(c))
 	if err != nil {
 		if err == repositories.NotFoundErr {
-			c.Status(http.StatusNotFound)
+			c.AbortWithStatus(http.StatusNotFound)
 		} else {
-			c.Status(http.StatusInternalServerError)
+			c.AbortWithStatus(http.StatusInternalServerError)
 		}
 		return
 	}
@@ -111,9 +111,9 @@ func (controller *LinkTagsController) GetTagsForLink(c *gin.Context) {
 	result, err := controller.repository.GetTagsForLink(id, GetUserInfo(c))
 	if err != nil {
 		if err == repositories.NotFoundErr {
-			c.Status(http.StatusNotFound)
+			c.AbortWithStatus(http.StatusNotFound)
 		} else {
-			c.Status(http.StatusInternalServerError)
+			c.AbortWithStatus(http.StatusInternalServerError)
 		}
 		return
 	}

--- a/controllers/links_controller.go
+++ b/controllers/links_controller.go
@@ -28,9 +28,9 @@ func (controller *LinksController) CreateLink(c *gin.Context) {
 	err = controller.repository.Create(&link, GetUserInfo(c))
 	if err != nil {
 		if err == repositories.AlreadyExistsErr {
-			c.Status(http.StatusBadRequest)
+			c.AbortWithStatus(http.StatusBadRequest)
 		} else {
-			c.Status(http.StatusInternalServerError)
+			c.AbortWithStatus(http.StatusInternalServerError)
 		}
 		return
 	}
@@ -47,9 +47,9 @@ func (controller *LinksController) DeleteLink(c *gin.Context) {
 	err = controller.repository.Delete(linkUuid, GetUserInfo(c))
 	if err != nil {
 		if err == repositories.NotFoundErr {
-			c.Status(http.StatusNotFound)
+			c.AbortWithStatus(http.StatusNotFound)
 		} else {
-			c.Status(http.StatusInternalServerError)
+			c.AbortWithStatus(http.StatusInternalServerError)
 		}
 		return
 	}


### PR DESCRIPTION
Closes #99.

This was not causing any errors (yet) but as that's the recommended approach, I've changed the code to reflect that.